### PR TITLE
fix: install for run_example.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,15 @@ aggregator/requirements.txt
 aggregator/artifacts/
 aggregator/mediafiles/**
 
+examples/django-deployment/mediafiles/
+examples/django-deployment/artifacts/
+examples/django-deployment/db.sqlite3
+examples/django-deployment/dump.rdb
+examples/client_examples/python_client/dataprofiler_developer/initial_model_schema.json
+examples/client_examples/python_client/dataprofiler_developer/initial_model_weights.json
+examples/client_examples/python_client/post_data.json
+examples/client_examples/python_client/dataprofiler_clients/uui_temp_*.txt
+examples/client_examples/python_client/dataprofiler_clients/logfile.log
 
 **/*.egg-info/*
 **/build/*

--- a/examples/client_examples/python_client/run_example.sh
+++ b/examples/client_examples/python_client/run_example.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+python -m venv venv
+source venv/bin/activate
+pip3 install -r requirements.txt
+pip3 install -r ./dataprofiler_clients/requirements.txt
+
 cd ./dataprofiler_developer/
 
 python3 create_initial_model_json_files.py


### PR DESCRIPTION
Currently, the run_example.sh does not install the necessary requirements. This adds it and updates the gitignore to not include the generated files from the example..