### PR TITLE
🐛 fix(Makefile): Add check to pip, pipenv, and postgresql installations

### DIFF
--- a/examples/django-deployment/Makefile
+++ b/examples/django-deployment/Makefile
@@ -57,7 +57,6 @@ else
   make compile-packages && make install
 endif
 
-	exit 1
 ifeq ($(shell uname -s), Linux)
 	apt-get install redis
 else ifeq ($(shell uname -s),Darwin)

--- a/examples/django-deployment/Makefile
+++ b/examples/django-deployment/Makefile
@@ -38,18 +38,19 @@ compile-packages:
 complete-install:
 
 ifeq (${PIP_PATH},)
-	python get-pip.py
+	curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+	python ./get-pip.py
 endif
 
 ifeq (${PG_CONFIG_PATH},)
-	ifeq ($(shell uname -s), Linux)
-		apt-get -y install postgresql
-	else ifeq ($(shell uname -s), Darwin)
-		brew install postgresql
-	else
-		echo "Error! redis not supported by $(shell uname -s)"
-		exit 125
-	endif
+ifeq ($(shell uname -s), Linux)
+	apt-get -y install postgresql
+else ifeq ($(shell uname -s), Darwin)
+	brew install postgresql
+else
+	echo "Error! redis not supported by $(shell uname -s)"
+	exit 125
+endif
 endif
 
 ifneq ($(shell pip list | grep pipenv | cut -d ' ' -f1),pipenv)

--- a/examples/django-deployment/Makefile
+++ b/examples/django-deployment/Makefile
@@ -38,22 +38,22 @@ complete-install:
 
 ifeq (${PG_CONFIG_PATH},)
 ifeq ($(shell uname -s), Linux)
-	apt-get -y install postgresql
+  apt-get -y install postgresql
 else ifeq ($(shell uname -s), Darwin)
-	brew install postgresql
+  brew install postgresql
 else
-	echo "Error! redis not supported by $(shell uname -s)"
-	exit 125
+  echo "Error! redis not supported by $(shell uname -s)"
+  exit 125
 endif
 endif
 
 ifneq ($(shell pip list | grep pipenv | cut -d ' ' -f1),pipenv)
-	pip install --user pipenv && \
-	export PATH=${PATH}:${USER_BIN_PATH} && \
-	make compile-packages && \
-	make install
+  pip install --user pipenv && \
+  export PATH=${PATH}:${USER_BIN_PATH} && \
+  make compile-packages && \
+  make install
 else
-	export PATH=${PATH}:${USER_BIN_PATH} && \
+  export PATH=${PATH}:${USER_BIN_PATH} && \
   make compile-packages && make install
 endif
 

--- a/examples/django-deployment/Makefile
+++ b/examples/django-deployment/Makefile
@@ -56,7 +56,7 @@ ifneq ($(shell pip list | grep pipenv | cut -d ' ' -f1),pipenv)
 	pip install --user pipenv
 endif
 
-	export PATH=${PATH}:${USER_BIN_PATH}
+	export PATH=${PATH}:${USER_BIN_PATH} && \
 	make compile-packages && make install
 
 ifeq ($(shell uname -s), Linux)

--- a/examples/django-deployment/Makefile
+++ b/examples/django-deployment/Makefile
@@ -48,7 +48,7 @@ ifeq ($(shell uname -s), Linux)
 else ifeq ($(shell uname -s), Darwin)
 	brew install postgresql
 else
-	echo "Error! redis not supported by $(shell uname -s)"
+	echo "Error! postgresql not supported by $(shell uname -s)"
 	exit 125
 endif
 endif

--- a/examples/django-deployment/Makefile
+++ b/examples/django-deployment/Makefile
@@ -1,6 +1,7 @@
 HOME_DIR = $(shell pwd)
 USER_BIN_PATH = $(shell python3 -m site --user-base)/bin
 PG_CONFIG_PATH = $(shell which pg_config)
+PIP_PATH = $(shell which pip)
 
 .PHONY: install
 install:
@@ -36,26 +37,27 @@ compile-packages:
 .PHONY: complete-install
 complete-install:
 
-ifeq (${PG_CONFIG_PATH},)
-ifeq ($(shell uname -s), Linux)
-  apt-get -y install postgresql
-else ifeq ($(shell uname -s), Darwin)
-  brew install postgresql
-else
-  echo "Error! redis not supported by $(shell uname -s)"
-  exit 125
+ifeq (${PIP_PATH},)
+	python get-pip.py
 endif
+
+ifeq (${PG_CONFIG_PATH},)
+	ifeq ($(shell uname -s), Linux)
+		apt-get -y install postgresql
+	else ifeq ($(shell uname -s), Darwin)
+		brew install postgresql
+	else
+		echo "Error! redis not supported by $(shell uname -s)"
+		exit 125
+	endif
 endif
 
 ifneq ($(shell pip list | grep pipenv | cut -d ' ' -f1),pipenv)
-  pip install --user pipenv && \
-  export PATH=${PATH}:${USER_BIN_PATH} && \
-  make compile-packages && \
-  make install
-else
-  export PATH=${PATH}:${USER_BIN_PATH} && \
-  make compile-packages && make install
+	pip install --user pipenv
 endif
+
+	export PATH=${PATH}:${USER_BIN_PATH}
+	make compile-packages && make install
 
 ifeq ($(shell uname -s), Linux)
 	apt-get install redis

--- a/examples/django-deployment/Makefile
+++ b/examples/django-deployment/Makefile
@@ -1,4 +1,6 @@
 HOME_DIR = $(shell pwd)
+USER_BIN_PATH = $(shell python3 -m site --user-base)/bin
+PG_CONFIG_PATH = $(shell which pg_config)
 
 .PHONY: install
 install:
@@ -33,7 +35,29 @@ compile-packages:
 
 .PHONY: complete-install
 complete-install:
-	make compile-packages && make install
+
+ifeq (${PG_CONFIG_PATH},)
+ifeq ($(shell uname -s), Linux)
+	apt-get -y install postgresql
+else ifeq ($(shell uname -s), Darwin)
+	brew install postgresql
+else
+	echo "Error! redis not supported by $(shell uname -s)"
+	exit 125
+endif
+endif
+
+ifneq ($(shell pip list | grep pipenv | cut -d ' ' -f1),pipenv)
+	pip install --user pipenv && \
+	export PATH=${PATH}:${USER_BIN_PATH} && \
+	make compile-packages && \
+	make install
+else
+	export PATH=${PATH}:${USER_BIN_PATH} && \
+  make compile-packages && make install
+endif
+
+	exit 1
 ifeq ($(shell uname -s), Linux)
 	apt-get install redis
 else ifeq ($(shell uname -s),Darwin)


### PR DESCRIPTION
This patch will perform a check to verify whether the `pip`, `pipenv` and `PostSQL` are already installed.  If they are not detected, it will proceed to install these applications.